### PR TITLE
replace deprecated create_function

### DIFF
--- a/featured-post.php
+++ b/featured-post.php
@@ -357,4 +357,4 @@ class Featured_Post_Widget extends WP_Widget
     }
 }
 
-add_action('widgets_init', create_function('', 'return register_widget("Featured_Post_Widget");'), 100);
+add_action('widgets_init', function() { return register_widget("Featured_Post_Widget"); }, 100);


### PR DESCRIPTION
The replacement uses closures, which were added in php 5.3.0